### PR TITLE
Silly npm error keeps popping up every time I do something. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,6 @@
       "url": "http://fullof.bs/"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/StoneCypher/flocks.js"
-    }
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/StoneCypher/flocks.js",


### PR DESCRIPTION
Error message was: npm WARN package.json flocks.js@1.6.1 'repositories' (plural) Not supported. Please pick one as the 'repository' field
